### PR TITLE
Use order in group/tab

### DIFF
--- a/led.js
+++ b/led.js
@@ -92,7 +92,7 @@ module.exports = function(RED) {
 	                format: HTML(config, ledStyleTemplate('gray')), 
 	                group: config.group,  
 	                templateScope: "local",
-	                order: 0,
+	                order: config.order,
 	                beforeEmit: beforeEmit,
 	                initController: initController
 				});


### PR DESCRIPTION
`order` in `addWidget` was being set to zero, should use `config.order`'s value as chosen from the Dashboard layout.

Thanks to @agenteDserrano for catching the bug and giving the fix in #19 !